### PR TITLE
allow export to STL without pre-merging

### DIFF
--- a/Application/QtFrontend/MainWindow.cpp
+++ b/Application/QtFrontend/MainWindow.cpp
@@ -162,6 +162,8 @@ void CMainWindow::on_actionExportAsStl_triggered()
     QString fileName = QFileDialog::getSaveFileName(this, tr("Save Scene as Stl"), "",
                                                     tr("Stl Files (*.stl);;All Files (*)"));
     // One shot merging, and add a new entity and its corresponding node
+    // Merge (can automatically do this)
+    bool merged = false;
     Scene->Update();
     Scene->ForEachSceneTreeNode([&](Scene::CSceneTreeNode* node) {
         if (node->GetOwner()->GetName() == "globalMergeNode")
@@ -170,9 +172,23 @@ void CMainWindow::on_actionExportAsStl_triggered()
             if (auto* mesh = dynamic_cast<Scene::CMeshMerger*>(entity))
             {
                 mesh->ExportAsStl(fileName);
+                merged = true;
             }
-        }
+        }    
     });
+    if (!merged) {
+        prepare_for_stl_no_merge();
+        Scene->ForEachSceneTreeNode([&](Scene::CSceneTreeNode* node) {
+        if (node->GetOwner()->GetName() == "globalMergeNode")
+        {
+            auto* entity = node->GetOwner()->GetEntity();
+            if (auto* mesh = dynamic_cast<Scene::CMeshMerger*>(entity))
+            {
+                mesh->ExportAsStl(fileName);
+            }
+        }    
+    });
+    }
 }
 
 
@@ -200,7 +216,53 @@ void CMainWindow::on_actionMerge_triggered()
             // set "auto * mesh" to this entity. Call MergeIn to set merger's vertices based on mesh's
             // vertices. Reminder: an instance identifier is NOT a Mesh, so only real entities get
             // merged.
-            merger->MergeIn(*mesh);
+            merger->MergeIn(*mesh, true);
+            entity->isMerged = true;
+        }
+    });
+
+    Scene->Update();
+    // TODO: 10/22 added.  These lines work to reset the scene
+    Scene->ForEachSceneTreeNode([&](Scene::CSceneTreeNode* node) {
+        if (node->GetOwner()->GetName() != "globalMergeNode")
+            node->GetOwner()->SetEntity(nullptr);
+    });
+
+
+    Scene->AddEntity(tc::static_pointer_cast<Scene::CEntity>(
+        merger)); // Merger now has all the vertices set, so we can add it into the scene as a new
+                  // entity
+    auto* sn = Scene->GetRootNode()->FindOrCreateChildNode("globalMergeNode"); // Add it into the Scene Tree by creating a new node called
+                            // globalMergeNode. Notice, this is the same name everytime you Merge.
+                            // This means you can only have one merger mesh each time. It will
+                            // override previous merger meshes with the new vertices.
+    sn->SetEntity(merger.Get()); // Set sn, which is the scene node, to point to entity merger
+}
+
+
+void CMainWindow::prepare_for_stl_no_merge()
+{
+    // One shot merging, and add a new entity and its corresponding node
+    Scene->Update();
+    // CmeshMerger is basically a CMesh, but with a MergeIn method. Merger will
+    // contain ALL the merged vertices (from various meshes)
+    tc::TAutoPtr<Scene::CMeshMerger> merger = new Scene::CMeshMerger("globalMerge");
+
+    Scene->ForEachSceneTreeNode([&](Scene::CSceneTreeNode* node) {
+        // If the node owner is a globalMergeNode, skip as that was a
+        // previously merger mesh (from a previous Merge iteration). We only
+        // want to merge vertices from our actual (non-merged) meshes.
+        if (node->GetOwner()->GetName() == "globalMergeNode")
+            return;
+        auto* entity = node->GetInstanceEntity(); // Else, get the instance
+        if (!entity) // Check to see if the an entity is instantiable
+        {
+            entity = node->GetOwner()->GetEntity(); // If it's not instantiable, get entity instead
+        } 
+        if (auto* mesh = dynamic_cast<Scene::CMeshInstance*>(entity))
+        {
+            // Call mergeIn but DO NOT actually merge adjacent vertices
+            merger->MergeIn(*mesh, false);
             entity->isMerged = true;
         }
     });

--- a/Application/QtFrontend/MainWindow.h
+++ b/Application/QtFrontend/MainWindow.h
@@ -52,6 +52,7 @@ private slots:
 
 
     void on_actionMerge_triggered();
+    void prepare_for_stl_no_merge();
     void on_actionSubdivide_triggered();
 
     /*  10/1 Randy Commenting out because these are not fully implemented right now

--- a/Application/Scene/MeshMerger.cpp
+++ b/Application/Scene/MeshMerger.cpp
@@ -129,7 +129,7 @@ void CMeshMerger::Catmull()
 }
 
 
-void CMeshMerger::MergeIn(CMeshInstance& meshInstance)
+void CMeshMerger::MergeIn(CMeshInstance& meshInstance, bool shouldMergePoints)
 {
     auto tf = meshInstance.GetSceneTreeNode()->L2WTransform.GetValue(
         tc::Matrix3x4::IDENTITY); // The transformation matrix is the identity matrix by default
@@ -162,7 +162,7 @@ void CMeshMerger::MergeIn(CMeshInstance& meshInstance)
 
         // to prevent adding two merger vertices in the same location!
 
-        if (distance < Epsilon)
+        if (distance < Epsilon && shouldMergePoints)
         { // this is to check for cases where there is an overlap (two vertices lie in the exact
             // same world space coordinate). We only want to create one merger vertex at this
             // location!

--- a/Application/Scene/MeshMerger.h
+++ b/Application/Scene/MeshMerger.h
@@ -30,7 +30,7 @@ public:
     }
 
     // No update yet, please just use one time
-    void MergeIn(CMeshInstance& meshInstance);
+    void MergeIn(CMeshInstance& meshInstance, bool shouldMergePoints);
 
     void MergeClear();
 

--- a/Application/Scene/Scene.cpp
+++ b/Application/Scene/Scene.cpp
@@ -317,7 +317,7 @@ void CScene::Update()
                             entity = node->GetOwner()->GetEntity(); // If it's not instantiable, get entity instead of instance entity
 
                         if (auto* mesh = dynamic_cast<Scene::CMeshInstance*>(entity)) { // set "auto * mesh" to this entity. Call MergeIn to set merger's vertices based on mesh's vertices. Reminder: an instance identifier is NOT a Mesh, so only real entities get merged.
-                            ent->MergeIn(*mesh);
+                            ent->MergeIn(*mesh, true); // Merge adjacent vertices
                             entity->isMerged = true;
                         }
 


### PR DESCRIPTION
First check if already merged, if so then proceed as usual. Otherwise, follow the same logic but do not merge adjacent vertices.