### PR TITLE
Add common import files for Include generator

### DIFF
--- a/ExampleFiles/intro_imports/colors.nom
+++ b/ExampleFiles/intro_imports/colors.nom
@@ -1,0 +1,18 @@
+#################  Define Colors  ######################
+surface R color (1 0 0) endsurface     # Red
+surface O color (0.9 0.6 0) endsurface # Orange
+surface Y color (1 1 0) endsurface     # Yellow
+surface L color (0.6 0.8 0) endsurface # Lime
+surface G color (0 0.9 0) endsurface   # Green
+surface A color (0 0.9 0.7) endsurface # Aqua
+surface C color (0 1 1) endsurface     # Cyan
+surface U color (0 0.5 1) endsurface   # Uniform
+surface B color (0 0 1) endsurface     # Blue
+surface P color (0.6 0 1) endsurface   # Purple
+surface M color (1 0 1) endsurface     # Magenta
+surface Z color (1 0 0.5) endsurface   # Zinnober
+
+surface W color (1 1 1) endsurface       # White
+surface D color (0.4 0.4 0.4) endsurface # Dark
+
+### backgroundcolor (0.6 0.7 0.8) endbackgroundcolor

--- a/ExampleFiles/intro_imports/global_axes.nom
+++ b/ExampleFiles/intro_imports/global_axes.nom
@@ -1,0 +1,15 @@
+###################  Global Coordinate Axes  ######################
+point ooo  ( 0 0 0 ) endpoint 
+point xoo  ( 1 0 0 ) endpoint
+point oyo  ( 0 1 0 ) endpoint
+point ooz  ( 0 0 1 ) endpoint
+
+polyline xaxis (ooo xoo) endpolyline
+polyline yaxis (ooo oyo) endpolyline
+polyline zaxis (ooo ooz) endpolyline
+
+group coord_axes   
+  instance ix xaxis surface R   endinstance     
+  instance iy yaxis surface B   endinstance
+  instance iz zaxis surface G   endinstance
+endgroup


### PR DESCRIPTION
Add files to be used with new file import command. 

JIPCAD files often start with the same shared code snippets, such as definitions for colors and global axes, however this is redundant. Instead, common snippets can be uploaded to the JIPCAD GitHub repo then imported in one line using a new `include` generator: ex. `include :intro_imports\colors.nom endinclude`

To test this new generator, the following import files should be merged first. PRs for following changes will come.